### PR TITLE
nextjs-spotify-public - Add Build Arg for Cache

### DIFF
--- a/aws-ecs-spot/outputs.tf
+++ b/aws-ecs-spot/outputs.tf
@@ -11,7 +11,7 @@ resource "local_file" "build-sh" {
   filename = "build.sh"
   content  = <<EOT
 aws ecr get-login-password --region ${var.region} | sudo docker login --username AWS --password-stdin ${var.account-id}.dkr.ecr.${var.region}.amazonaws.com
-sudo docker build . -t nextjs-spotify-public:latest -t ${aws_ecr_repository.testing.repository_url}:latest
+sudo docker build . -t nextjs-spotify-public:latest -t ${aws_ecr_repository.testing.repository_url}:latest --build-arg CACHE=1
 # sudo docker tag nextjs-spotify-public:latest ${aws_ecr_repository.testing.repository_url}:latest
 sudo docker push ${var.account-id}.dkr.ecr.${var.region}.amazonaws.com/${var.name}:latest
   EOT

--- a/nextjs-spotify-public/Dockerfile
+++ b/nextjs-spotify-public/Dockerfile
@@ -3,5 +3,6 @@ FROM node:18-alpine
 COPY package.json .
 RUN npm install
 COPY . .
+ARG CACHE=0
 RUN npm run build
 CMD npm run start


### PR DESCRIPTION
Allows me to easily build a new `npm build` layer