### PR TITLE
nextjs-spotify-public - Use EC2 ASG vs. ECR

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -120,6 +120,7 @@ jobs:
         echo "task=$task" >> $GITHUB_OUTPUT
 
     - name: ECS Stop Task
+      if: false
       run: |
         aws ecs stop-task --task ${{ steps.listTasks.outputs.task }} --cluster ${{ steps.listClusters.outputs.cluster }}
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -29,10 +29,10 @@ name: Deploy to Amazon ECS
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 7-22/4 * * *'
+    - cron:  '0 7-22/6 * * *'
 
-  push:
-    branches: [ "main", "**" ]
+  # push:
+  #   branches: [ "main", "**" ]
 
   workflow_dispatch:
 

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -33,7 +33,7 @@ on:
 
   push:
     branches: [ "main", "**" ]
-    
+
   workflow_dispatch:
 
 env:
@@ -90,7 +90,7 @@ jobs:
         # push: ${{ github.event_name != 'pull_request' }}
         push: true
         tags: ${{env.ECR_REGISTRY}}/${{env.ECR_REPOSITORY}}:latest
-        labels: latest
+        # labels: latest
         # cache-from: type=gha
         # cache-to: type=gha,mode=max
         build-args: |

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -32,7 +32,7 @@ on:
     - cron:  '0 7-22/4 * * *'
 
   push:
-    # branches: [ "main", "**" ]
+    branches: [ "main", "**" ]
     
   workflow_dispatch:
 
@@ -90,7 +90,7 @@ jobs:
         # push: ${{ github.event_name != 'pull_request' }}
         push: true
         tags: ${{env.ECR_REGISTRY}}/${{env.ECR_REPOSITORY}}:latest
-        # labels: ${{ steps.meta.outputs.labels }}
+        labels: latest
         # cache-from: type=gha
         # cache-to: type=gha,mode=max
         build-args: |

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -90,7 +90,7 @@ jobs:
         # push: ${{ github.event_name != 'pull_request' }}
         push: true
         tags: ${{env.ECR_REGISTRY}}/${{env.ECR_REPOSITORY}}:latest
-        # labels: latest
+        # labels: ${{ steps.meta.outputs.labels }}
         # cache-from: type=gha
         # cache-to: type=gha,mode=max
         build-args: |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+hxrsmurf

--- a/nextjs-spotify-public/aws/update-cloudflare/ReadMe.md
+++ b/nextjs-spotify-public/aws/update-cloudflare/ReadMe.md
@@ -4,6 +4,8 @@ This handles the EC2 Auto Scaling Notification and updated the Cloudflare DNS Re
 
 I have the website on a t3.micro Spot EC2 Instance with ECS.
 
+2023-03-12 - ECS is 30 GiB AMI so switched to EC2 ASG with user data.
+
 # Docs
 - https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
 

--- a/nextjs-spotify-public/aws/update-cloudflare/code/functions/parse.py
+++ b/nextjs-spotify-public/aws/update-cloudflare/code/functions/parse.py
@@ -1,0 +1,8 @@
+from .ec2 import describe_instances
+
+def parse_sns(record):
+    # Parse EC2 Information
+    instance_id = event['detail']['EC2InstanceId']
+    instance_information = describe_instances(instance_id)['Reservations'][0]['Instances'][0]
+    public_ip = instance_information['PublicIpAddress']
+    return public_ip

--- a/nextjs-spotify-public/aws/update-cloudflare/code/index.py
+++ b/nextjs-spotify-public/aws/update-cloudflare/code/index.py
@@ -4,16 +4,12 @@ from functions.ec2 import describe_instances
 from functions.cloudflare import update_dns_record
 
 def lambda_handler(event, context):
-    # Parse SNS Message
-    record = event['Records'][0]
-    sns_message = record['Sns']
-    subject = sns_message['Subject']
-    message = json.loads(sns_message['Message'])
-
-    if subject == 'Auto Scaling: launch':
+    # Parse Auto Scaling Event
+    print(event)
+    run = True
+    if run:
         # Parse EC2 Information
-        instance_id = message['EC2InstanceId']
+        instance_id = event['detail']['EC2InstanceId']
         instance_information = describe_instances(instance_id)['Reservations'][0]['Instances'][0]
         public_ip = instance_information['PublicIpAddress']
-
         update_dns_record(ip_address=public_ip)

--- a/nextjs-spotify-public/aws/update-cloudflare/examples/auto-scaling-event.json
+++ b/nextjs-spotify-public/aws/update-cloudflare/examples/auto-scaling-event.json
@@ -1,0 +1,31 @@
+{
+    "version": "0",
+    "id": "56b87b44-8017-e8ca-6c75-7ff181efef54",
+    "detail-type": "EC2 Instance Launch Successful",
+    "source": "aws.autoscaling",
+    "account": "195663387853",
+    "time": "2023-03-13T01:40:50Z",
+    "region": "us-east-1",
+    "resources": [
+        "arn:aws:autoscaling:us-east-1:195663387853:autoScalingGroup:3eb8bbde-c020-42e4-816d-fa224bef4a40:autoScalingGroupName/nextjs-spotify-public",
+        "arn:aws:ec2:us-east-1:195663387853:instance/i-0b29b9c54260e6b73"
+    ],
+    "detail": {
+        "Origin": "EC2",
+        "Destination": "AutoScalingGroup",
+        "Description": "Launching a new EC2 instance: i-0b29b9c54260e6b73",
+        "EndTime": "2023-03-13T01:40:50.253Z",
+        "RequestId": "0a461b62-821a-567a-529c-9ddd26d0a4b3",
+        "ActivityId": "0a461b62-821a-567a-529c-9ddd26d0a4b3",
+        "StartTime": "2023-03-13T01:40:44.309Z",
+        "EC2InstanceId": "i-0b29b9c54260e6b73",
+        "StatusCode": "InProgress",
+        "StatusMessage": "",
+        "Details": {
+            "Subnet ID": "subnet-06f20fbf166bf2252",
+            "Availability Zone": "us-east-1d"
+        },
+        "Cause": "At 2023-03-13T01:40:32Z a user request update of AutoScalingGroup constraints to min: 1, max: 2, desired: 1 changing the desired capacity from 0 to 1.  At 2023-03-13T01:40:41Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 0 to 1.",
+        "AutoScalingGroupName": "nextjs-spotify-public"
+    }
+}

--- a/nextjs-spotify-public/aws/user-data.sh
+++ b/nextjs-spotify-public/aws/user-data.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+yum install docker jq -y
+export AWS_DEFAULT_REGION=us-east-1
+systemctl start docker
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 195663387853.dkr.ecr.us-east-1.amazonaws.com
+sha=`aws ecr list-images --repository-name testing | jq -r ".imageIds [0] .imageDigest"`
+docker run -p 80:3000 195663387853.dkr.ecr.us-east-1.amazonaws.com/testing@$sha


### PR DESCRIPTION
The ECR AMI is 30 GiB. So moving to EC2 8 GiB. 

I had to update the Lambda to parse an AutoScaling Group SNS rather than ECS SNS.