### PR TITLE
nextjs-spotify-public - Add EC2 ASG Management

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -59,6 +59,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      if: false
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -70,13 +71,16 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
+      if: false
 
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+      if: false
 
     - name: Delete Year
       working-directory: nextjs-spotify-public
       run: rm -rf pages/2022.tsx
+      if: false
 
     - name: Build and push Docker image
       id: build-and-push
@@ -84,6 +88,7 @@ jobs:
       uses: docker/build-push-action@v4
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      if: false
       with:
         context: nextjs-spotify-public
         file: ./nextjs-spotify-public/Dockerfile
@@ -108,12 +113,14 @@ jobs:
 
     - name: ECS List Clusters
       id: listClusters
+      if: false
       run: |
         cluster=$(aws ecs list-clusters | jq .clusterArns[0])
         echo "cluster=$cluster" >> $GITHUB_OUTPUT
 
     - name: ECS List Tasks
       id: listTasks
+      if: false
       run: |
         task=$(aws ecs list-tasks --cluster ${{ steps.listClusters.outputs.cluster }} | jq .taskArns[0])
         echo $task

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -115,7 +115,7 @@ jobs:
       id: listASG
       if: true
       run: |
-        asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'].InstanceId" --output json)
+        asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'].InstanceId" --output text)
         echo "asg=$asg" >> $GITHUB_OUTPUT
 
     - name: ECS List Clusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -24,15 +24,15 @@
 #    See the documentation for each action used below for the recommended IAM policies for this IAM user,
 #    and best practices on handling the access key credentials.
 
-name: Deploy to Amazon ECS
+name: Deploy to AWS ECR and EC2
 
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 7-22/6 * * *'
 
-  push:
-    branches: [ "nextjs-spotify-public/*"]
+  # push:
+  #   branches: [ "nextjs-spotify-public/*"]
 
   workflow_dispatch:
 
@@ -59,7 +59,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      if: false
+      if: true
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -71,16 +71,16 @@ jobs:
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1
-      if: false
+      if: true
 
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
-      if: false
+      if: true
 
     - name: Delete Year
       working-directory: nextjs-spotify-public
       run: rm -rf pages/2022.tsx
-      if: false
+      if: true
 
     - name: Build and push Docker image
       id: build-and-push
@@ -88,7 +88,7 @@ jobs:
       uses: docker/build-push-action@v4
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-      if: false
+      if: true
       with:
         context: nextjs-spotify-public
         file: ./nextjs-spotify-public/Dockerfile

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -117,6 +117,7 @@ jobs:
       run: |
         asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'].InstanceId" --output text)
         echo "asg=$asg" >> $GITHUB_OUTPUT
+        echo "asg=$asg" >> $GITHUB_STEP_SUMMARY
 
     - name: ECS List Clusters
       id: listClusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -115,7 +115,7 @@ jobs:
       id: listASG
       if: true
       run: |
-        asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'")
+        asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'].InstanceId" --output json)
         echo "asg=$asg" >> $GITHUB_OUTPUT
 
     - name: ECS List Clusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -117,7 +117,14 @@ jobs:
       run: |
         asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'].InstanceId" --output text)
         echo "asg=$asg" >> $GITHUB_OUTPUT
-        echo "asg=$asg" >> $GITHUB_STEP_SUMMARY
+        echo "$asg" >> $GITHUB_STEP_SUMMARY
+
+    - name: Set ASG Instance Unhealthy
+      id: setASGUnhealthy
+      if: true
+      run: |
+        echo ${{ steps.listAsg.outputs.asg }}
+        echo ${{ steps.listAsg.outputs.asg }} >> $GITHUB_STEP_SUMMARY
 
     - name: ECS List Clusters
       id: listClusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -121,10 +121,11 @@ jobs:
 
     - name: Set ASG Instance Unhealthy
       id: setASGUnhealthy
+      env:
+        instance_id: ${{ steps.listAsg.outputs.asg }}
       if: true
       run: |
-        echo ${{ steps.listAsg.outputs.asg }}
-        echo ${{ steps.listAsg.outputs.asg }} >> $GITHUB_STEP_SUMMARY
+        aws autoscaling set-instance-health $instance_id --health-status "Unhealthy" --no-should-respect-grace-period
 
     - name: ECS List Clusters
       id: listClusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -125,7 +125,7 @@ jobs:
         instance_id: ${{ steps.listAsg.outputs.asg }}
       if: true
       run: |
-        aws autoscaling set-instance-health $instance_id --health-status "Unhealthy" --no-should-respect-grace-period
+        aws autoscaling set-instance-health --instance-id $instance_id --health-status "Unhealthy" --no-should-respect-grace-period
 
     - name: ECS List Clusters
       id: listClusters

--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -31,8 +31,8 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 7-22/6 * * *'
 
-  # push:
-  #   branches: [ "main", "**" ]
+  push:
+    branches: [ "nextjs-spotify-public/*"]
 
   workflow_dispatch:
 
@@ -110,6 +110,13 @@ jobs:
           DEVICE_SAMSUNG=${{ secrets.DEVICE_SAMSUNG }}
           LATEST_MONTH=${{ secrets.LATEST_MONTH }}
           LATEST_YEAR=${{ secrets.LATEST_YEAR }}
+
+    - name: EC2 List AutoScaling Group
+      id: listASG
+      if: true
+      run: |
+        asg=$(aws autoscaling describe-auto-scaling-instances --query "AutoScalingInstances[?AutoScalingGroupName=='nextjs-spotify-public'")
+        echo "asg=$asg" >> $GITHUB_OUTPUT
 
     - name: ECS List Clusters
       id: listClusters


### PR DESCRIPTION
I previously used ECS and re-created the task as needed. But this defaults to 30 GiB EBS. So I moved to EC2 8 GiB with ASG.